### PR TITLE
feat: add size prop to icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@vue/compiler-dom": "^3.0.5",
     "autoprefixer": "^10.4.14",
     "camelcase": "^6.0.0",
+    "cheerio": "^1.0.0-rc.12",
     "html-to-image": "1.9.0",
     "postcss": "^8.4.23",
     "prettier": "^2.8.7",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,5 +1,6 @@
 const fs = require('fs').promises
 const camelcase = require('camelcase')
+const cheerio = require('cheerio')
 const { promisify } = require('util')
 const rimraf = promisify(require('rimraf'))
 const svgr = require('@svgr/core').default
@@ -20,11 +21,16 @@ let transform = {
       large: 64,
     };
 
+    const svgElement = cheerio.load(svg)('svg')
+    const svgViewBox = svgElement.attr('viewBox').split(" ")
+
+    const width = Number(svgViewBox[2]);
+    const height = Number(svgViewBox[3]);
+
     let lines = code.split('\n');
     lines.splice(1, 0, `\nconst sizeMap = ${JSON.stringify(SIZE_MAP, null, 2)};\n`);
-    lines.splice(5, 0, '  size,');
-    lines.splice(14, 0, '    width: size ? typeof size === "string" ? sizeMap[size] : size : "32px",');
-    lines.splice(15, 0, '    height: size ? typeof size === "string" ? sizeMap[size] : size : "32px",');
+    lines.splice(5, 0, `  size,`);
+    lines.splice(14, 0, `    ${width >= height ? 'width' : 'height'}: size ? typeof size === "string" ? sizeMap[size] : size : "32px",`);
     code = lines.join('\n');
 
     if (format === 'esm') {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -14,6 +14,19 @@ let transform = {
       plugins: [[require('@babel/plugin-transform-react-jsx'), { useBuiltIns: true }]],
     })
 
+    const SIZE_MAP = {
+      small: 16,
+      medium: 32,
+      large: 64,
+    };
+
+    let lines = code.split('\n');
+    lines.splice(1, 0, `\nconst sizeMap = ${JSON.stringify(SIZE_MAP, null, 2)};\n`);
+    lines.splice(5, 0, '  size,');
+    lines.splice(14, 0, '    width: size ? typeof size === "string" ? sizeMap[size] : size : "32px",');
+    lines.splice(15, 0, '    height: size ? typeof size === "string" ? sizeMap[size] : size : "32px",');
+    code = lines.join('\n');
+
     if (format === 'esm') {
       return code
     }
@@ -93,7 +106,7 @@ async function buildIcons(package, style, format) {
       let content = await transform[package](svg, componentName, format)
       let types =
         package === 'react'
-          ? `import * as React from 'react';\ndeclare const ${componentName}: React.ForwardRefExoticComponent<React.PropsWithoutRef<React.SVGProps<SVGSVGElement>> & { title?: string, titleId?: string } & React.RefAttributes<SVGSVGElement>>;\nexport default ${componentName};\n`
+          ? `import * as React from 'react';\ndeclare const ${componentName}: React.ForwardRefExoticComponent<React.PropsWithoutRef<React.SVGProps<SVGSVGElement>> & { title?: string, titleId?: string, size?: "small" | "medium" | "large" | number } & React.RefAttributes<SVGSVGElement>>;\nexport default ${componentName};\n`
           : `import type { FunctionalComponent, HTMLAttributes, VNodeProps } from 'vue';\ndeclare const ${componentName}: FunctionalComponent<HTMLAttributes & VNodeProps>;\nexport default ${componentName};\n`
 
       return [

--- a/src/IconsGallery.tsx
+++ b/src/IconsGallery.tsx
@@ -68,12 +68,12 @@ const IconLine = (props: { name: string }) => {
 */
   // @ts-expect-error ts-migrate(7053)
   const IconComponent = Icons[name];
-  const StyledIcon = () => <IconComponent className="w-4 h-4 inline-block select-none align-text-bottom overflow-visible" />;
+  const StyledIcon = () => <IconComponent size="small" className="inline-block select-none align-text-bottom overflow-visible" />;
   const icon = <Box alignItems="center" justifyContent="space-between">
     <BorderStyle>
       <SpanStyle>
         <span>
-          <IconComponent className="w-16 inline-block select-none align-text-bottom overflow-visible" />
+          <IconComponent size="large" className="inline-block select-none align-text-bottom overflow-visible" />
         </span>
       </SpanStyle>
     </BorderStyle>


### PR DESCRIPTION
Fixes #7

Adds `size` prop to the React Components

Default is set to be 32px i.e. medium

Type definition is set to `"small | "medium" | "large" | number`

Uses viewBox to decide which prop to add (since we might be adding icons of rectangular sizes in the future and the size (small, medium, large) should be the value of the largest side of the rectangle, while the smaller side is decided as per the aspect ratio)