### PR TITLE
feat: add colored prop

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -30,8 +30,11 @@ let transform = {
     let lines = code.split('\n');
     lines.splice(1, 0, `\nconst sizeMap = ${JSON.stringify(SIZE_MAP, null, 2)};\n`);
     lines.splice(5, 0, `  size,`);
+    lines.splice(6, 0, `  colored,`);
     lines.splice(14, 0, `    ${width >= height ? 'width' : 'height'}: size ? typeof size === "string" ? sizeMap[size] : size : "16px",`);
     code = lines.join('\n');
+
+    code = code.replaceAll(/fill: "([#a-zA-Z0-9]+)",/g, `fill: colored ? '$1' : 'currentColor',`);
 
     if (format === 'esm') {
       return code
@@ -112,7 +115,7 @@ async function buildIcons(package, style, format) {
       let content = await transform[package](svg, componentName, format)
       let types =
         package === 'react'
-          ? `import * as React from 'react';\ndeclare const ${componentName}: React.ForwardRefExoticComponent<React.PropsWithoutRef<React.SVGProps<SVGSVGElement>> & { title?: string, titleId?: string, size?: "small" | "medium" | "large" | number } & React.RefAttributes<SVGSVGElement>>;\nexport default ${componentName};\n`
+          ? `import * as React from 'react';\ndeclare const ${componentName}: React.ForwardRefExoticComponent<React.PropsWithoutRef<React.SVGProps<SVGSVGElement>> & { title?: string, titleId?: string, size?: "small" | "medium" | "large" | number, colored?: boolean } & React.RefAttributes<SVGSVGElement>>;\nexport default ${componentName};\n`
           : `import type { FunctionalComponent, HTMLAttributes, VNodeProps } from 'vue';\ndeclare const ${componentName}: FunctionalComponent<HTMLAttributes & VNodeProps>;\nexport default ${componentName};\n`
 
       return [

--- a/src/IconsGallery.tsx
+++ b/src/IconsGallery.tsx
@@ -73,6 +73,13 @@ const IconLine = (props: { name: string }) => {
     <BorderStyle>
       <SpanStyle>
         <span>
+          <IconComponent colored size="large" className="inline-block select-none align-text-bottom overflow-visible" />
+        </span>
+      </SpanStyle>
+    </BorderStyle>
+    <BorderStyle>
+      <SpanStyle>
+        <span>
           <IconComponent size="large" className="inline-block select-none align-text-bottom overflow-visible" />
         </span>
       </SpanStyle>


### PR DESCRIPTION
Fixes #10

Although it's a bit problematic as the SVGs being added to the repo have to be proper (clipped instead of using white fill, less gradients etc.)

But in the worst case, we can use the colored prop to avoid overwriting.