### PR TITLE
fix: prevent white colors from changing

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -34,7 +34,7 @@ let transform = {
     lines.splice(14, 0, `    ${width >= height ? 'width' : 'height'}: size ? typeof size === "string" ? sizeMap[size] : size : "16px",`);
     code = lines.join('\n');
 
-    if (style === "solid") code = code.replaceAll(/fill: "([#a-zA-Z0-9]+)",/g, `fill: colored ? '$1' : 'currentColor',`);
+    if (style === "solid") code = code.replaceAll(/fill: "([#a-zA-Z0-9]+)",/g, `fill: colored ? '$1' : (['#fff', '#fffff', 'white', '#FFF', '#FFFFFF'].includes('$1') ? 'white' : 'currentColor'),`);
 
     if (format === 'esm') {
       return code


### PR DESCRIPTION
Partly fixes #14

This prevents the white colors of the icon from changing, not sure how reliable this is. The other way would be to only have clipped icons in the svgs so that would be see-through in the white space...

<img width="914" alt="Screenshot 2023-05-09 at 10 32 16 PM" src="https://github.com/datalayer/icons/assets/64399555/f1e8b71f-770d-4a77-bd7a-fb01c2895f86">
